### PR TITLE
Re fix of the nasty URL redirection bug (on a branch of its own, to avoi...

### DIFF
--- a/docs/urls.py
+++ b/docs/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import patterns, url
 from docs import views
 
 urlpatterns = patterns('',
-	url(r'(?P<page>(\w|/)*)\.md$', views.redirect_md),
-	url(r'corporations/(?P<corporation_slug>(\w|/)*)$', views.corporation),
-	url(r'(?P<page>(\w|/)*)$', views.index),
+	url(r'(?P<page>(\w|/|-)*)\.md$', views.redirect_md),
+	url(r'corporations/(?P<corporation_slug>(\w|/|-)*)$', views.corporation),
+	url(r'(?P<page>(\w|/|-)*)$', views.index),
 )


### PR DESCRIPTION
...d catatrophes)

Previously, the redirection to Saeder-Krupp from docs failed because of the "-".
Not sure the fix is enough, maybe we should discuss what shape URLs can take